### PR TITLE
Update Sudoku notebook for release JuMP 0.19

### DIFF
--- a/notebooks/JuMP-Sudoku.ipynb
+++ b/notebooks/JuMP-Sudoku.ipynb
@@ -7,11 +7,11 @@
     "## Disclaimer\n",
     "This notebook is only working under the versions:\n",
     "\n",
-    "- JuMP 0.19 (unreleased, but currently in master)\n",
+    "- JuMP 0.19\n",
     "\n",
-    "- MathOptInterface 0.4.1\n",
+    "- MathOptInterface 0.8.4\n",
     "\n",
-    "- GLPK 0.6.0"
+    "- GLPK 0.9.1"
    ]
   },
   {
@@ -48,9 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -88,14 +86,12 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "9×9×9 Array{JuMP.VariableRef,3}:\n",
+       "9×9×9 Array{VariableRef,3}:\n",
        "[:, :, 1] =\n",
        " x[1,1,1]  x[1,2,1]  x[1,3,1]  x[1,4,1]  …  x[1,7,1]  x[1,8,1]  x[1,9,1]\n",
        " x[2,1,1]  x[2,2,1]  x[2,3,1]  x[2,4,1]     x[2,7,1]  x[2,8,1]  x[2,9,1]\n",
@@ -203,7 +199,7 @@
    ],
    "source": [
     "# Create a model\n",
-    "sudoku = Model(optimizer = GLPK.GLPKOptimizerMIP())\n",
+    "sudoku = Model(with_optimizer(GLPK.Optimizer))\n",
     "\n",
     "# Create our variables\n",
     "@variable(sudoku, x[i=1:9, j=1:9, k=1:9], Bin)"
@@ -219,9 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for i = 1:9, j = 1:9  # Each row and each column\n",
@@ -242,9 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for ind = 1:9  # Each row, OR each column\n",
@@ -267,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for i = 1:3:7, j = 1:3:7, k = 1:9\n",
@@ -289,9 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The given digits\n",
@@ -317,29 +305,25 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# solve problem\n",
-    "JuMP.optimize(sudoku)"
+    "optimize!(sudoku)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JuMP.hasresultvalues(sudoku) = true\n",
-      "JuMP.terminationstatus(sudoku) == MOI.Success = true\n",
-      "JuMP.primalstatus(sudoku) == MOI.FeasiblePoint = true\n"
+      "has_values(sudoku) = true\n",
+      "termination_status(sudoku) == MOI.OPTIMAL = true\n",
+      "primal_status(sudoku) == MOI.FEASIBLE_POINT = true\n"
      ]
     },
     {
@@ -355,9 +339,9 @@
    ],
    "source": [
     "# test if optimization worked out properly\n",
-    "@show JuMP.hasresultvalues(sudoku)\n",
-    "@show JuMP.terminationstatus(sudoku) == MOI.Success\n",
-    "@show JuMP.primalstatus(sudoku) == MOI.FeasiblePoint"
+    "@show has_values(sudoku)\n",
+    "@show termination_status(sudoku) == MOI.OPTIMAL\n",
+    "@show primal_status(sudoku) == MOI.FEASIBLE_POINT"
    ]
   },
   {
@@ -370,9 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -396,7 +378,7 @@
    ],
    "source": [
     "# Extract the values of x\n",
-    "x_val = JuMP.resultvalue.(x)\n",
+    "x_val = value.(x)\n",
     "# Create a matrix to store the solution\n",
     "sol = zeros(Int,9,9)  # 9x9 matrix of integers\n",
     "for i in 1:9, j in 1:9, k in 1:9\n",
@@ -432,15 +414,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.6.0",
+   "display_name": "Julia 1.0.3",
    "language": "julia",
-   "name": "julia-0.6"
+   "name": "julia-1.0"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.6.0"
+   "version": "1.0.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Most of the notebooks don't work with the current release of JuMP 0.19 but are instead based on a past dev version. Updating the notebooks makes it easier to reuse contents for the planned JuMPTutorials.jl package.

@chriscoey @joaquimg