### PR TITLE
Update README.md to mention JuMPTutorials.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # juliaopt-notebooks
+
 A collection of IJulia notebooks related to optimization
 
 [NBViewer link](http://nbviewer.ipython.org/github/JuliaOpt/juliaopt-notebooks/tree/master/notebooks/)
 
-This is a work in progress.
+This repository is old and unmaintained, i.e. the examples are possibly outdated wrt the latest version of JuMP.
+Please use [JuMPTutorials.jl](https://github.com/JuliaOpt/JuMPTutorials.jl) instead.


### PR DESCRIPTION
I'm new to JuMP - thanks for all your work!

I was confused at first wrt where to find up-to-date examples, I think it's here now?https://github.com/JuliaOpt/JuMPTutorials.jl

This PR mentions this in the README of this older repo.

@barpit20 @matbesancon @mlubin - thoughts?